### PR TITLE
Added a publicly available basemap (token is not required)

### DIFF
--- a/src/eoapi/raster/eoapi/raster/templates/stac-viewer.html
+++ b/src/eoapi/raster/eoapi/raster/templates/stac-viewer.html
@@ -295,34 +295,51 @@
         </div>
 
         <script>
-    var scope = {
-        assets: undefined,
-        info: undefined,
-    }
+var scope = { assets: undefined, info: undefined }
 
-    mapboxgl.accessToken = ''
+mapboxgl.accessToken = ''
 
-    const dtype_ranges = {
-      'int8': [-128, 127],
-      'uint8': [0, 255],
-      'uint16': [0, 65535],
-      'int16': [-32768, 32767],
-      'uint32': [0, 4294967295],
-      'int32': [-2147483648, 2147483647],
-      'float32': [-3.4028235e+38, 3.4028235e+38],
-      'float64': [-1.7976931348623157e+308, 1.7976931348623157e+308]
-    }
-
-let style
-if (mapboxgl.accessToken !== '') {
-    style = 'mapbox://styles/mapbox/{{ mapbox_style }}-v9'
-} else {
-    style = { version: 8, sources: {}, layers: [] }
+const dtype_ranges = {
+    'int8': [-128, 127],
+    'uint8': [0, 255],
+    'uint16': [0, 65535],
+    'int16': [-32768, 32767],
+    'uint32': [0, 4294967295],
+    'int32': [-2147483648, 2147483647],
+    'float32': [-3.4028235e+38, 3.4028235e+38],
+    'float64': [-1.7976931348623157e+308, 1.7976931348623157e+308]
 }
+
+mapboxgl.accessToken = ''
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: style,
+    style: {
+      version: 8,
+      sources: {
+        'toner-lite': {
+          type: 'raster',
+          tiles: [
+            'http://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            'http://stamen-tiles-b.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            'http://stamen-tiles-c.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            'http://stamen-tiles-d.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
+          ],
+          tileSize: 256,
+          attribution:
+            'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+        }
+      },
+      layers: [
+        {
+          'id': 'basemap',
+          'type': 'raster',
+          'source': 'toner-lite',
+          'minzoom': 0,
+          'maxzoom': 20
+        }
+      ]
+    },
     center: [0, 0],
     zoom: 1
 })

--- a/src/eoapi/stac/eoapi/stac/app.py
+++ b/src/eoapi/stac/eoapi/stac/app.py
@@ -59,14 +59,9 @@ if tiles_settings.titiler_endpoint:
 @app.get("/index.html", response_class=HTMLResponse)
 async def viewer_page(request: Request):
     """Search viewer."""
-    print(request.url)
     return templates.TemplateResponse(
         "stac-viewer.html",
-        {
-            "request": request,
-            "endpoint": str(request.url).replace("/index.html", ""),
-            "mapbox_token": api_settings.mapbox_token,
-        },
+        {"request": request, "endpoint": str(request.url).replace("/index.html", "")},
         media_type="text/html",
     )
 

--- a/src/eoapi/stac/eoapi/stac/config.py
+++ b/src/eoapi/stac/eoapi/stac/config.py
@@ -12,7 +12,6 @@ class _ApiSettings(pydantic.BaseSettings):
     name: str = "eoAPI-stac"
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
-    mapbox_token: str = ""
     debug: bool = False
 
     @pydantic.validator("cors_origins")

--- a/src/eoapi/stac/eoapi/stac/templates/stac-viewer.html
+++ b/src/eoapi/stac/eoapi/stac/templates/stac-viewer.html
@@ -291,7 +291,32 @@ let style
 if (mapboxgl.accessToken !== '') {
   style = 'mapbox://styles/mapbox/dark-v9'
 } else {
-  style = { version: 8, sources: {}, layers: [] }
+  style = {
+    version: 8,
+    sources: {
+      'toner-lite': {
+        type: 'raster',
+        tiles: [
+          'http://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+          'http://stamen-tiles-b.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+          'http://stamen-tiles-c.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+          'http://stamen-tiles-d.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
+        ],
+        tileSize: 256,
+        attribution:
+          'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+      }
+    },
+    layers: [
+      {
+        'id': 'basemap',
+        'type': 'raster',
+        'source': 'toner-lite',
+        'minzoom': 0,
+        'maxzoom': 20
+      }
+    ]
+  }
 }
 
 var map = new mapboxgl.Map({

--- a/src/eoapi/stac/eoapi/stac/templates/stac-viewer.html
+++ b/src/eoapi/stac/eoapi/stac/templates/stac-viewer.html
@@ -285,43 +285,36 @@
       <script>
 var scope = { collections: undefined, features: [], next_token: undefined, limit: 100, query: {}}
 
-mapboxgl.accessToken = '{{ mapbox_token }}'
-
-let style
-if (mapboxgl.accessToken !== '') {
-  style = 'mapbox://styles/mapbox/dark-v9'
-} else {
-  style = {
-    version: 8,
-    sources: {
-      'toner-lite': {
-        type: 'raster',
-        tiles: [
-          'http://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-          'http://stamen-tiles-b.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-          'http://stamen-tiles-c.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-          'http://stamen-tiles-d.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
-        ],
-        tileSize: 256,
-        attribution:
-          'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
-      }
-    },
-    layers: [
-      {
-        'id': 'basemap',
-        'type': 'raster',
-        'source': 'toner-lite',
-        'minzoom': 0,
-        'maxzoom': 20
-      }
-    ]
-  }
-}
+mapboxgl.accessToken = ''
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: style,
+    style: {
+      version: 8,
+      sources: {
+        'toner-lite': {
+          type: 'raster',
+          tiles: [
+            'http://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            'http://stamen-tiles-b.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            'http://stamen-tiles-c.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            'http://stamen-tiles-d.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
+          ],
+          tileSize: 256,
+          attribution:
+            'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+        }
+      },
+      layers: [
+        {
+          'id': 'basemap',
+          'type': 'raster',
+          'source': 'toner-lite',
+          'minzoom': 0,
+          'maxzoom': 20
+        }
+      ]
+    },
     center: [0, 0],
     zoom: 1
 })


### PR DESCRIPTION
By now in order to have a basemap for the search viewer user have to provide a mapbox token via environment variable. This PR adds a default basemap (Dark Matter basemaps from Carto) which doesn't require any preconfigurations.
![image](https://user-images.githubusercontent.com/866124/132552033-11c1df41-5df6-4495-a284-9a421cb6dce9.png)