### PR TITLE
Register postgis extension on user DB using superuser role, to avoid permissions issues.

### DIFF
--- a/deployment/handlers/db_handler.py
+++ b/deployment/handlers/db_handler.py
@@ -141,6 +141,23 @@ def handler(event, context):
 
             print("Registering extensions...")
             register_extensions(cursor=cur)
+        
+        # Install extensions on the user DB with
+        # superuser permissions, since they will
+        # otherwise fail to install when run as
+        # the non-superuser within the pgstac
+        # migrations.
+        conn = psycopg2.connect(
+            dbname=user_params.get("dbname", "postgres"),
+            user=connection_params["username"],
+            password=connection_params["password"],
+            host=connection_params["host"],
+            port=connection_params["port"],
+        )
+        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with conn.cursor() as cur:
+            print("Registering extensions on pgstac db...")
+            register_extensions(cursor=cur)
 
         conn = psycopg2.connect(
             dbname=user_params.get("dbname", "postgres"),


### PR DESCRIPTION
# What's the issue?

I ran into this issue when adapting this code for use with csdap-orders and spinning up a new DB. The pypgstac migrations attempt to register postgis in the pgstac DB, if it isn't already present. Since the migrations are run as as non-superuser, registering the extension fails.

# How am I fixing it?

This isn't a perfect fix, since pypgstac could always be updated in the future to attempt to register other extensions, but for now I'm just registering the postgis extension on the pgstac DB using the superuser credentials. This allows the migrations to run with the non-superuser, as they won't attempt to register the extension if it already exists.
