### PR TITLE
introduce new HACK for stac -> raster proxy

### DIFF
--- a/.github/workflows/tests/test_raster.py
+++ b/.github/workflows/tests/test_raster.py
@@ -94,6 +94,7 @@ def test_stac_api():
     }
     itemb64 = b64encode(json.dumps(item).encode()).decode()
 
+    # stac://
     resp = httpx.get(
         f"{raster_endpoint}/stac/assets", params={"url": f"stac://{itemb64}"}
     )
@@ -104,6 +105,28 @@ def test_stac_api():
     resp = httpx.get(
         f"{raster_endpoint}/stac/tilejson.json",
         params={"url": f"stac://{itemb64}", "assets": "cog"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/json"
+    assert resp.json()["tilejson"]
+    assert "assets=cog" in resp.json()["tiles"][0]
+    assert resp.json()["bounds"] == [-85.5501, 36.1749, -85.5249, 36.2001]
+
+    # pg://
+    resp = httpx.get(
+        f"{raster_endpoint}/stac/assets",
+        params={"url": "pg://noaa-emergency-response/20200307aC0853300w361200"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/json"
+    assert resp.json() == ["cog"]
+
+    resp = httpx.get(
+        f"{raster_endpoint}/stac/tilejson.json",
+        params={
+            "url": "pg://noaa-emergency-response/20200307aC0853300w361200",
+            "assets": "cog",
+        },
     )
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/json"

--- a/.github/workflows/tests/test_raster.py
+++ b/.github/workflows/tests/test_raster.py
@@ -112,7 +112,7 @@ def test_stac_api():
     assert "assets=cog" in resp.json()["tiles"][0]
     assert resp.json()["bounds"] == [-85.5501, 36.1749, -85.5249, 36.2001]
 
-    # pg://
+    # pgstac://
     resp = httpx.get(
         f"{raster_endpoint}/stac/assets",
         params={"url": "pgstac://noaa-emergency-response/20200307aC0853300w361200"},

--- a/.github/workflows/tests/test_raster.py
+++ b/.github/workflows/tests/test_raster.py
@@ -115,7 +115,7 @@ def test_stac_api():
     # pg://
     resp = httpx.get(
         f"{raster_endpoint}/stac/assets",
-        params={"url": "pg://noaa-emergency-response/20200307aC0853300w361200"},
+        params={"url": "pgstac://noaa-emergency-response/20200307aC0853300w361200"},
     )
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/json"
@@ -124,7 +124,7 @@ def test_stac_api():
     resp = httpx.get(
         f"{raster_endpoint}/stac/tilejson.json",
         params={
-            "url": "pg://noaa-emergency-response/20200307aC0853300w361200",
+            "url": "pgstac://noaa-emergency-response/20200307aC0853300w361200",
             "assets": "cog",
         },
     )

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ A custom version of [stac-fastapi](https://github.com/stac-utils/stac-fastapi), 
   - `/collections/{collectionId}/items/{itemId}/tilejson.json`: Return the `raster` tilejson for an items
   - `/collections/{collectionId}/items/{itemId}/viewer`: Redirect to the `raster` viewer
 
-  **important**: The extension implement a `trick` to avoid unnecessary requests between the `raster` api and the `stac` api. Instead of passing a STAC Item url we encode (base64) the full item (see [raster/reader.py](https://github.com/developmentseed/eoAPI/blob/b845e11460195b6305189c498a6cf1fdc9e95abc/src/eoapi/raster/eoapi/raster/reader.py#L24-L27))
+  **important**: The extension implement a `trick` to avoid unnecessary requests between the `raster` api and the `stac` api. Instead of passing a STAC Item url we encode (base64) the full item (see [raster/reader.py](https://github.com/developmentseed/eoAPI/blob/b845e11460195b6305189c498a6cf1fdc9e95abc/src/eoapi/raster/eoapi/raster/reader.py#L24-L27)). If the stac item is too big, we are using a second trick by passing `pgstac://{collectionid}/{itemid}` as the url which will be used by the api to directly get the item from the database.
 
   ```
   # normal url
   http://{raster}/stac/tilejson.json?url=http://{stac}/collections/{collectionId}/items/{itemId}
 
   # url used in proxy
-  http://{raster}/stac/tilejson.json?url=stac://{base64 encoded item}
+  http://{raster}/stac/tilejson.json?url=stac://{base64 encoded item} or http://{raster}/stac/tilejson.json?url=pgstac://{collectionId}/{itemId}
   ```
 
 <p align="center">

--- a/src/eoapi/raster/eoapi/raster/app.py
+++ b/src/eoapi/raster/eoapi/raster/app.py
@@ -13,6 +13,7 @@ from titiler.pgstac.db import close_db_connection, connect_to_db
 from titiler.pgstac.factory import MosaicTilerFactory
 
 from eoapi.raster.config import ApiSettings
+from eoapi.raster.dependencies import DatasetPathParams
 from eoapi.raster.factory import MultiBaseTilerFactory
 from eoapi.raster.reader import STACReader
 from eoapi.raster.version import __version__ as eoapi_raster_version
@@ -35,6 +36,7 @@ app.include_router(mosaic.router, prefix="/mosaic", tags=["PgSTAC Mosaic"])
 # Custom STAC titiler endpoint (not added to the openapi docs)
 stac = MultiBaseTilerFactory(
     reader=STACReader,
+    path_dependency=DatasetPathParams,
     router_prefix="stac",
     optional_headers=optional_headers,
 )

--- a/src/eoapi/raster/eoapi/raster/dependencies.py
+++ b/src/eoapi/raster/eoapi/raster/dependencies.py
@@ -56,7 +56,7 @@ def DatasetPathParams(
     if parsed.scheme == "stac":
         return json.loads(b64decode(url.replace("stac://", "")))
 
-    # pg://{collectionId}/{itemId}
+    # pgstac://{collectionId}/{itemId}
     elif parsed.scheme == "pgstac":
         collection_id = parsed.netloc
         item_id = parsed.path.strip("/")

--- a/src/eoapi/raster/eoapi/raster/dependencies.py
+++ b/src/eoapi/raster/eoapi/raster/dependencies.py
@@ -1,0 +1,71 @@
+"""eoapi.raster.dependencies."""
+
+import json
+from base64 import b64decode
+from typing import Dict, Union
+from urllib.parse import urlparse
+
+from cachetools import LRUCache, cached
+from cachetools.keys import hashkey
+
+from fastapi import Query
+from starlette.requests import Request
+
+
+@cached(
+    LRUCache(maxsize=512),
+    key=lambda pool, collection_id, item_id: hashkey(collection_id, item_id),
+)
+def get_item(pool, collection_id, item_id):
+    """Get STAC Item from PGStac."""
+    req = dict(
+        filter={
+            "op": "and",
+            "args": [
+                {
+                    "op": "eq",
+                    "args": [{"property": "collection"}, collection_id],
+                },
+                {"op": "eq", "args": [{"property": "id"}, item_id]},
+            ],
+        },
+    )
+    with pool.connection() as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM search(%s);",
+                (json.dumps(req),),
+            )
+            resp = cursor.fetchone()[0]
+            features = resp.get("features", [])
+            if not len(features):
+                raise Exception(
+                    "No item '{item_id}' found in '{collection_id}' collection"
+                )
+
+            return features[0]
+
+
+def DatasetPathParams(
+    request: Request, url: str = Query(..., description="Dataset URL")
+) -> Union[str, Dict]:
+    """Custom Dataset Param for the custom STAC Reader"""
+    parsed = urlparse(url)
+
+    # stac://{base 64 encoded item}
+    if parsed.scheme == "stac":
+        return json.loads(b64decode(url.replace("stac://", "")))
+
+    # pg://{collectionId}/{itemId}
+    elif parsed.scheme == "pg":
+        collection_id = parsed.netloc
+        item_id = parsed.path.strip("/")
+        return get_item(
+            request.app.state.dbpool,
+            collection_id,
+            item_id,
+        )
+
+    # Default to passing the URL
+    else:
+        return url

--- a/src/eoapi/raster/eoapi/raster/dependencies.py
+++ b/src/eoapi/raster/eoapi/raster/dependencies.py
@@ -57,7 +57,7 @@ def DatasetPathParams(
         return json.loads(b64decode(url.replace("stac://", "")))
 
     # pg://{collectionId}/{itemId}
-    elif parsed.scheme == "pg":
+    elif parsed.scheme == "pgstac":
         collection_id = parsed.netloc
         item_id = parsed.path.strip("/")
         return get_item(

--- a/src/eoapi/raster/eoapi/raster/factory.py
+++ b/src/eoapi/raster/eoapi/raster/factory.py
@@ -1,6 +1,7 @@
 """Custom MultiBaseTilerFactory."""
 
 from dataclasses import dataclass
+from typing import Any
 
 from fastapi import Depends
 from starlette.requests import Request
@@ -31,7 +32,7 @@ class MultiBaseTilerFactory(factory.MultiBaseTilerFactory):
         @self.router.get("/viewer", response_class=HTMLResponse)
         def stac_demo(
             request: Request,
-            src_path: str = Depends(self.path_dependency),
+            src_path: Any = Depends(self.path_dependency),
         ):
             """STAC Viewer."""
             return templates.TemplateResponse(
@@ -39,7 +40,9 @@ class MultiBaseTilerFactory(factory.MultiBaseTilerFactory):
                 context={
                     "request": request,
                     "endpoint": request.url.path.replace("/viewer", ""),
-                    "stac_url": src_path,
+                    "stac_url": request.query_params[
+                        "url"
+                    ],  # Warning: This assume that `self.path_dependency` uses `url=`
                 },
                 media_type="text/html",
             )

--- a/src/eoapi/raster/eoapi/raster/reader.py
+++ b/src/eoapi/raster/eoapi/raster/reader.py
@@ -1,30 +1,69 @@
-"""Custom Reader.
+"""Custom STAC reader."""
 
-This is based on an original idea from Daniel J. Dufour, ref: https://github.com/cogeotiff/rio-tiler/issues/408
-"""
-
-import json
-from base64 import b64decode
+from typing import Dict, Optional, Set, Type, Union
 
 import attr
 import pystac
-from rio_tiler.io import stac
+from morecantile import TileMatrixSet
+from rasterio.crs import CRS
+from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
+from rio_tiler.errors import MissingAssets
+from rio_tiler.io import BaseReader, COGReader, stac
 
 
 @attr.s
 class STACReader(stac.STACReader):
-    """Custom STACReader.
+    """Custom STAC Reader."""
 
-    This reader allows input to be in form of `stac://{base64 encoded STAC items}
+    input: Union[str, Dict] = attr.ib()  # Input can be of type String or Dict
+    item: pystac.Item = attr.ib(init=False)
 
-    """
+    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+    minzoom: int = attr.ib(default=None)
+    maxzoom: int = attr.ib(default=None)
+
+    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
+
+    include_assets: Optional[Set[str]] = attr.ib(default=None)
+    exclude_assets: Optional[Set[str]] = attr.ib(default=None)
+
+    include_asset_types: Set[str] = attr.ib(default=stac.DEFAULT_VALID_TYPE)
+    exclude_asset_types: Optional[Set[str]] = attr.ib(default=None)
+
+    reader: Type[BaseReader] = attr.ib(default=COGReader)
+    reader_options: Dict = attr.ib(factory=dict)
+
+    fetch_options: Dict = attr.ib(factory=dict)
 
     def __attrs_post_init__(self):
-        """Decode data: urls."""
-        if self.input and self.input.startswith("stac://"):
+        """Fetch STAC Item and get list of valid assets."""
+        if isinstance(self.input, (Dict, pystac.Item)):
+            self.item = stac._to_pystac_item(self.input)
+        else:
             self.item = pystac.Item.from_dict(
-                json.loads(b64decode(self.input.replace("stac://", "")))
+                stac.fetch(self.input, **self.fetch_options), self.input
             )
-            self.input = None
 
-        super().__attrs_post_init__()
+        # TODO: get bounds/crs using PROJ extension if available
+        self.bounds = self.item.bbox
+        self.crs = WGS84_CRS
+
+        self.assets = list(
+            stac._get_assets(
+                self.item,
+                include=self.include_assets,
+                exclude=self.exclude_assets,
+                include_asset_types=self.include_asset_types,
+                exclude_asset_types=self.exclude_asset_types,
+            )
+        )
+        if not self.assets:
+            raise MissingAssets("No valid asset found")
+
+        if self.minzoom is None:
+            # TODO get minzoom from PROJ extension
+            self.minzoom = self.tms.minzoom
+
+        if self.maxzoom is None:
+            # TODO get maxzoom from PROJ extension
+            self.maxzoom = self.tms.maxzoom

--- a/src/eoapi/stac/eoapi/stac/extension.py
+++ b/src/eoapi/stac/eoapi/stac/extension.py
@@ -109,7 +109,7 @@ class TiTilerExtension(ApiExtension):
             item = json.dumps(items["features"][0])
             itemb64 = b64encode(item.encode())
             if len(itemb64) > MAX_B64_ITEM_SIZE:
-                stac_url = f"pg://{collectionId}/{itemId}"
+                stac_url = f"pgstac://{collectionId}/{itemId}"
             else:
                 stac_url = f"stac://{itemb64.decode()}"
 
@@ -176,7 +176,7 @@ class TiTilerExtension(ApiExtension):
             item = json.dumps(items["features"][0])
             itemb64 = b64encode(item.encode())
             if len(itemb64) > MAX_B64_ITEM_SIZE:
-                stac_url = f"pg://{collectionId}/{itemId}"
+                stac_url = f"pgstac://{collectionId}/{itemId}"
             else:
                 stac_url = f"stac://{itemb64.decode()}"
 

--- a/src/eoapi/stac/eoapi/stac/extension.py
+++ b/src/eoapi/stac/eoapi/stac/extension.py
@@ -18,6 +18,8 @@ from eoapi.stac.config import post_request_model as POSTModel
 
 router = APIRouter()
 
+MAX_B64_ITEM_SIZE = 2000
+
 
 @attr.s
 class TiTilerExtension(ApiExtension):
@@ -106,6 +108,10 @@ class TiTilerExtension(ApiExtension):
 
             item = json.dumps(items["features"][0])
             itemb64 = b64encode(item.encode())
+            if len(itemb64) > MAX_B64_ITEM_SIZE:
+                stac_url = f"pg://{collectionId}/{itemId}"
+            else:
+                stac_url = f"stac://{itemb64.decode()}"
 
             qs_key_to_remove = [
                 "tile_format",
@@ -118,7 +124,7 @@ class TiTilerExtension(ApiExtension):
                 for (key, value) in request.query_params._list
                 if key.lower() not in qs_key_to_remove
             ]
-            qs.append(("url", f"stac://{itemb64.decode()}"))
+            qs.append(("url", stac_url))
 
             return RedirectResponse(
                 titiler_endpoint + f"/stac/tilejson.json?{urlencode(qs)}"
@@ -169,9 +175,13 @@ class TiTilerExtension(ApiExtension):
 
             item = json.dumps(items["features"][0])
             itemb64 = b64encode(item.encode())
+            if len(itemb64) > MAX_B64_ITEM_SIZE:
+                stac_url = f"pg://{collectionId}/{itemId}"
+            else:
+                stac_url = f"stac://{itemb64.decode()}"
 
             qs = [(key, value) for (key, value) in request.query_params._list]
-            qs.append(("url", f"stac://{itemb64.decode()}"))
+            qs.append(("url", stac_url))
 
             return RedirectResponse(titiler_endpoint + f"/stac/viewer?{urlencode(qs)}")
 


### PR DESCRIPTION
close issue #29 

Instead of passing the item URL I'm using a new custom schema `pgstac://{collectionid}/{itemid}`.

Fetching the STAC item is cached so it should reduce the number of call to the DB

cc @sharkinsspatial 