### PR TITLE
Pin markupsafe version

### DIFF
--- a/src/eoapi/raster/setup.py
+++ b/src/eoapi/raster/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 inst_reqs = [
     "titiler.pgstac==0.1.0a3",
-    "jinja2>=2.11.2,<3.0.0",
+    "jinja2>=3.0,<4.0",
     "starlette-cramjam>=0.1.0,<0.2",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]

--- a/src/eoapi/stac/setup.py
+++ b/src/eoapi/stac/setup.py
@@ -10,7 +10,7 @@ inst_reqs = [
     "stac-fastapi.types~=2.3",
     "stac-fastapi.extensions~=2.3",
     "stac-fastapi.pgstac~=2.3",
-    "jinja2>=2.11.2,<3.0.0",
+    "jinja2>=3.0,<4.0",
     "starlette-cramjam>=0.1.0.a0,<0.2",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]

--- a/src/eoapi/vector/setup.py
+++ b/src/eoapi/vector/setup.py
@@ -13,7 +13,7 @@ inst_reqs = [
     "asyncpg",
     "stac-pydantic~=2.0",
     "geojson-pydantic>=0.3.1,<0.4",
-    "jinja2>=2.11.2,<3.0.0",
+    "jinja2>=3.0,<4.0",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]
 


### PR DESCRIPTION
https://github.com/pallets/markupsafe/issues/286

```
>>> import jinja2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/usr/local/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/usr/local/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.9/site-packages/markupsafe/__init__.py)
```