### PR TITLE
Use "black" profile when running isort (commit hooks)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,8 @@ repos:
   - repo: https://github.com/PyCQA/isort
     rev: 5.4.2
     hooks:
-      - id: isort
+      - id: isort 
+        args: ["--profile", "black"]
         language_version: python
 
   - repo: https://github.com/PyCQA/flake8


### PR DESCRIPTION
There are some incompatibilities between the standard configurations for isort and black ([ref](https://github.com/PyCQA/isort/issues/1518). 

To avoid issues of black and isort continuously reformatting the same file, add the `--profile black` option to isort
