### PR TITLE
update deployment guide with a few more details

### DIFF
--- a/infrastructure/DEPLOYMENT.md
+++ b/infrastructure/DEPLOYMENT.md
@@ -5,10 +5,11 @@ An example of Cloud Stack is available for AWS (RDS for the database and Lambda 
 
 The stack is deployed by the [AWS CDK](https://aws.amazon.com/cdk/) utility. Under the hood, CDK will create the deployment packages required for AWS Lambda, upload it to AWS, and handle the creation of the Lambda and API Gateway resources.
 
-1. Install CDK and connect to your AWS account. This step is only necessary once per AWS account.
+The example commands here will deploy a CloudFormation stack called `eoAPI-staging`.
 
+1. Clone the `eoapi` repo and install dependencies
     ```bash
-    # Download titiler repo
+    # Download eoapi repo
     git clone https://github.com/developmentseed/eoapi.git
 
     # Create a virtual environment
@@ -18,17 +19,24 @@ The stack is deployed by the [AWS CDK](https://aws.amazon.com/cdk/) utility. Und
 
     # install cdk dependencies
     python -m pip install -r infrastructure/aws/requirements-cdk.txt
-
-    # Install node dependency
-    npm --prefix infrastructure/aws install
-
-    # Deploys the CDK toolkit stack into an AWS environment
-    npm --prefix infrastructure/aws run cdk -- bootstrap
-    # or to a specific region
-    AWS_DEFAULT_REGION=us-west-2 AWS_REGION=us-west-2 npm --prefix infrastructure/aws run cdk -- bootstrap
     ```
 
-2. Update settings
+2. Install node dependency - requires node version 14+
+    ```bash
+    npm --prefix infrastructure/aws install
+    ```
+
+3. Install CDK and connect to your AWS account. This step is only necessary once per AWS account. The environment variable `CDK_EOAPI_STAGE` determines the name of the stack
+(e.g. eoAPI-staging or eoAPI-production)
+    ```bash
+    # Deploy the CDK toolkit stack into an AWS environment.
+    CDK_EOAPI_STAGE=staging CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1 npm --prefix infrastructure/aws run cdk -- bootstrap
+
+    # or to a specific region
+    AWS_DEFAULT_REGION=us-west-2 AWS_REGION=us-west-2 CDK_EOAPI_STAGE=staging CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1 npm --prefix infrastructure/aws run cdk -- bootstrap
+    ```
+
+4. Update settings
 
     Set environment variable or hard code in `infrastructure/aws/.env` file (e.g `CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1`).
 
@@ -36,19 +44,19 @@ The stack is deployed by the [AWS CDK](https://aws.amazon.com/cdk/) utility. Und
       - `CDK_EOAPI_DB_PGSTAC_VERSION` is a required env
       - You can choose which functions to deploy by setting `CDK_EOAPI_FUNCTIONS` env (e.g `CDK_EOAPI_FUNCTIONS='["stac","raster","vector"]'`)
 
-3. Pre-Generate CFN template
+5. Pre-Generate CFN template
 
     ```bash
-    npm --prefix infrastructure/aws run cdk -- synth  # Synthesizes and prints the CloudFormation template for this stack
+    CDK_EOAPI_STAGE=staging CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1 npm --prefix infrastructure/aws run cdk -- synth  # Synthesizes and prints the CloudFormation template for this stack
     ```
 
-4. Deploy
+6. Deploy
 
     ```bash
-    CDK_EOAPI_STAGE=staging CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1 npm --prefix infrastructure/aws run cdk -- deploy eoapi-staging
+    CDK_EOAPI_STAGE=staging CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1 npm --prefix infrastructure/aws run cdk -- deploy eoAPI-${CDK_EOAPI_STAGE}
 
     # Deploy in specific region
-    AWS_DEFAULT_REGION=eu-central-1 AWS_REGION=eu-central-1 CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1 npm --prefix infrastructure/aws run cdk -- deploy eoapi-production --profile {my-aws-profile}
+    AWS_DEFAULT_REGION=eu-central-1 AWS_REGION=eu-central-1 CDK_EOAPI_STAGE=staging CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1 npm --prefix infrastructure/aws run cdk -- deploy eoapi-${CDK_EOAPI_STAGE} --profile {my-aws-profile}
     ```
 
 If you get an error saying that the max VPC's has been reached, this means that you have hit the limit for the amount of VPCs per unique AWS account and region combination. You can change the AWS region to a region that has less VPCs and deploy again to fix this.


### PR DESCRIPTION
Here are a few suggested changes to the deployment guide based on my experience with it yesterday. This is a really great tool, I'm excited to replace my cobbled together stac-fastapi-pgstac + titiler-pgstac deployment with this!

The main change I needed to get things running was to add the `CDK_EOAPI_STAGE` env var to deployment commands because it determines the name of the stack and it needs to be consistent across the steps.
