### PR TITLE
Update deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Note: services might have incompatible dependencies which you can resolve by usi
 
 This repository has current runtimes that are consistently updated with new functionality. 
 
-The services can be deployed locally via docker with `docker-compose up`.
+The services can be deployed locally via docker with `docker-compose up`. The official runtimes can be launched with `docker-compose -f docker-compose.yml -f docker-compose.official.yml up stac-fastapi titiler-pgstac tipg`. 
 
-Two IaC repositories are available:
+Two Infrastructure as Code (IaC) repositories are available:
 - [eoapi-cdk](https://github.com/developmentseed/eoapi-cdk): A set of AWS CDK constructs to deploy eoAPI services
 - [eoapi-k8s](https://github.com/developmentseed/eoapi-k8s): IaC and Helm charts for deploying eoAPI services on AWS and GCP
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ Note: services might have incompatible dependencies which you can resolve by usi
 
 ## Deployment
 
-This repository has the demonstration runtimes that are consistently updated with new functionality.
+This repository has current runtimes that are consistently updated with new functionality. 
 
-The default runtimes are available through separate repositories ([eoapi-cdk](https://github.com/developmentseed/eoapi-cdk) and [eoapi-k8s](https://github.com/developmentseed/eoapi-k8s)). 
+The services can be deployed locally via docker with `docker-compose up`.
 
-A demonstration application is accessible with the repository [eoapi-template](https://github.com/developmentseed/eoapi-template).
+Two IaC repositories are available:
+- [eoapi-cdk](https://github.com/developmentseed/eoapi-cdk): A set of AWS CDK constructs to deploy eoAPI services
+- [eoapi-k8s](https://github.com/developmentseed/eoapi-k8s): IaC and Helm charts for deploying eoAPI services on AWS and GCP
+
+Finally, [eoapi-template](https://github.com/developmentseed/eoapi-template) is an AWS CDK app that shows how to configure the eoapi-cdk constructs.
 
 ## Contribution & Development
 

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -3,13 +3,15 @@ hide:
   - navigation
 ---
 
-The default runtimes are available through separate repositories ([eoapi-cdk](https://github.com/developmentseed/eoapi-cdk) and [eoapi-k8s](https://github.com/developmentseed/eoapi-k8s)). 
 
-A demonstration application is accessible with the repository [eoapi-template](https://github.com/developmentseed/eoapi-template).
+## Via [eoapi-cdk](https://github.com/developmentseed/eoapi-cdk)
 
-## AWS (Lambda)
 
-An example of Cloud Stack is available for AWS (RDS for the database and Lambda for the APIs)
+[eoapi-cdk](https://github.com/developmentseed/eoapi-cdk) is a set of AWS CDK constructs to deploy eoAPI services.
+
+[eoapi-template](https://github.com/developmentseed/eoapi-template) is an AWS CDK app that shows how to configure the [eoapi-cdk](https://github.com/developmentseed/eoapi-cdk) constructs.
+
+An example of Cloud Stack is available for AWS (RDS for the database and Lambda for the APIs).
 
 The stack is deployed by the [AWS CDK](https://aws.amazon.com/cdk/) utility. Under the hood, CDK will create the deployment packages required for AWS Lambda, upload it to AWS, and handle the creation of the Lambda and API Gateway resources.
 
@@ -86,6 +88,73 @@ The example commands here will deploy a CloudFormation stack called `eoAPI-stagi
 
 If you get an error saying that the max VPC's has been reached, this means that you have hit the limit for the amount of VPCs per unique AWS account and region combination. You can change the AWS region to a region that has less VPCs and deploy again to fix this.
 
-## K8S
+## Via [eoapi-k8s](https://github.com/developmentseed/eoapi-k8s)
 
-A Kubernetes chart is currently being developed at https://github.com/developmentseed/eoapi-k8s
+[eoapi-k8s](https://github.com/developmentseed/eoapi-k8s) has the IaC and Helm charts for deploying eoAPI services on AWS and GCP.
+
+**Getting started**
+
+If you don't have a k8s cluster set up on AWS or GCP then follow an IaC guide below that is relevant to you
+
+> &#9432; The helm chart in this repo assumes your cluster has a few third-party add-ons and controllers installed. So
+> it's in your best interest to read through the IaC guides to understand what those defaults are
+
+* [AWS EKS Cluster Setup](./docs/aws-eks.md)
+
+* [TBD: GCP GKE Cluster Setup](./docs/gcp-gke.md)
+ 
+**Helm Installation** 
+
+Once you have a k8s cluster set up you can `helm install` eoAPI as follows
+
+1. `helm install` from this repo's `helm-chart/` folder:
+
+    ```python
+      ######################################################
+      # create os environment variables for required secrets
+      ######################################################
+      $ export GITSHA=$(git rev-parse HEAD | cut -c1-10)
+      $ export PGUSER=s00pers3cr3t
+      $ export POSTGRES_USER=s00pers3cr3t
+      $ export POSTGRES_PASSWORD=superuserfoobar
+      $ export PGPASSWORD=foobar
+   
+      $ cd ./helm-chart
+
+      $ helm install \
+          --namespace eoapi \
+          --create-namespace \
+          --set gitSha=$GITSHA \
+          --set db.settings.secrets.PGUSER=$PGUSER \
+          --set db.settings.secrets.POSTGRES_USER=$POSTGRES_USER \
+          --set db.settings.secrets.PGPASSWORD=$PGPASSWORD \
+          --set db.settings.secrets.POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
+          eoapi \
+          ./eoapi
+    ```
+
+2. or `helm install` from https://devseed.com/eoapi-k8s/:
+
+    ```python
+      # add the eoapi helm repo locally
+      $ helm repo add eoapi https://devseed.com/eoapi-k8s/
+    
+      # list out the eoapi chart versions
+      $ helm search repo eoapi 
+      NAME            CHART VERSION   APP VERSION     DESCRIPTION                                       
+      eoapi/eoapi     0.1.1           0.1.0           Create a full Earth Observation API with Metada...
+      eoapi/eoapi     0.1.2           0.1.0           Create a full Earth Observation API with Metada...
+   
+      # add the required secret overrides to an arbitrarily named `.yaml` file (`config.yaml` below)
+      $ cat config.yaml 
+      db:
+        settings:
+          secrets:
+            PGUSER: "username"
+            POSTGRES_USER: "username"
+            PGPASSWORD: "password"
+            POSTGRES_PASSWORD: "password"
+    
+      # then run `helm install` with those overrides 
+      helm install eoapi eoapi/eoapi --version 0.1.1 -f config.yaml
+    ```


### PR DESCRIPTION
Add description and pointers to eoapi-template, eoapi-cdk, eoapi-k8s. Add information on running services with docker-compose to deployment section. Refactor mkdocs deployment to reference sub-repositories and follow similar formatting for k8s vs. cdk approach.

Followed recommendations from @vincentsarago and @sharkinsspatial [here](https://github.com/developmentseed/eoAPI/pull/114#discussion_r1265878767). Let me know if I missed interpreted anything or if you have other suggestions!