### PR TITLE
update titiler-pgstac and tipg to last version compatible with pydantic 1.0

### DIFF
--- a/.github/workflows/tests/test_raster.py
+++ b/.github/workflows/tests/test_raster.py
@@ -30,7 +30,7 @@ def test_mosaic_api():
     assert list(resp.json()[0]) == ["id", "bbox", "assets", "collection"]
     assert resp.json()[0]["id"] == "20200307aC0853900w361030"
 
-    resp = httpx.get(f"{raster_endpoint}/mosaic/{searchid}/15/8589/12849/assets")
+    resp = httpx.get(f"{raster_endpoint}/mosaic/{searchid}/tiles/15/8589/12849/assets")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
     assert list(resp.json()[0]) == ["id", "bbox", "assets", "collection"]

--- a/infrastructure/aws/handlers/raster_handler.py
+++ b/infrastructure/aws/handlers/raster_handler.py
@@ -6,9 +6,17 @@ import os
 
 from eoapi.raster.app import app
 from mangum import Mangum
+from titiler.pgstac.db import connect_to_db
 
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    """Connect to database on startup."""
+    await connect_to_db(app)
+
 
 handler = Mangum(app, lifespan="off")
 

--- a/infrastructure/aws/handlers/stac_handler.py
+++ b/infrastructure/aws/handlers/stac_handler.py
@@ -6,9 +6,17 @@ import os
 
 from eoapi.stac.app import app
 from mangum import Mangum
+from stac_fastapi.pgstac.db import connect_to_db
 
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    """Connect to database on startup."""
+    await connect_to_db(app)
+
 
 handler = Mangum(app, lifespan="off")
 

--- a/runtime/eoapi/raster/eoapi/raster/config.py
+++ b/runtime/eoapi/raster/eoapi/raster/config.py
@@ -1,17 +1,16 @@
 """API settings."""
 
-from functools import lru_cache
-
 import pydantic
 
 
-class _ApiSettings(pydantic.BaseSettings):
+class ApiSettings(pydantic.BaseSettings):
     """API settings"""
 
     name: str = "eoAPI-raster"
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
+    root_path: str = ""
 
     @pydantic.validator("cors_origins")
     def parse_cors_origin(cls, v):
@@ -23,16 +22,3 @@ class _ApiSettings(pydantic.BaseSettings):
 
         env_file = ".env"
         env_prefix = "EOAPI_RASTER_"
-
-
-@lru_cache()
-def ApiSettings() -> _ApiSettings:
-    """
-    This function returns a cached instance of the APISettings object.
-    Caching is used to prevent re-reading the environment every time the API settings are used in an endpoint.
-    If you want to change an environment variable and reset the cache (e.g., during testing), this can be done
-    using the `lru_cache` instance method `get_api_settings.cache_clear()`.
-
-    From https://github.com/dmontagu/fastapi-utils/blob/af95ff4a8195caaa9edaa3dbd5b6eeb09691d9c7/fastapi_utils/api_settings.py#L60-L69
-    """
-    return _ApiSettings()

--- a/runtime/eoapi/raster/pyproject.toml
+++ b/runtime/eoapi/raster/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler.pgstac==0.4.1",
+    "titiler.pgstac==0.5.1",
     "starlette-cramjam>=0.3,<0.4",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]

--- a/runtime/eoapi/stac/pyproject.toml
+++ b/runtime/eoapi/stac/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    "fastapi>=0.95.1",
+    "pydantic~=1.0",
+    "geojson-pydantic~=0.6",
     "stac-fastapi.api~=2.4",
     "stac-fastapi.types~=2.4",
     "stac-fastapi.extensions~=2.4",

--- a/runtime/eoapi/vector/pyproject.toml
+++ b/runtime/eoapi/vector/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "tipg==0.2.0",
+    "tipg==0.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
closes #116 

This PR does:
- update tipg to 0.3.0 
- update titiler-pgstac to 0.5.1 
- update lambda handlers to add `startup_event` (removed in the main application because we now use lifespan method)
- update stac requirements 