### PR TITLE
add a config parameter for db instance size

### DIFF
--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -40,6 +40,9 @@ The example commands here will deploy a CloudFormation stack called `eoAPI-stagi
 
     Set environment variable or hard code in `infrastructure/aws/.env` file (e.g `CDK_EOAPI_DB_PGSTAC_VERSION=0.7.1`).
 
+    To modify the size of the burstable database instance, modify `CDK_EOAPI_DB_INSTANCE_SIZE` to one of the values of [`aws_cdk.aws_ec2.InstanceSize`](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/InstanceSize.html#instancesize).
+    The default size is `SMALL`.
+
     **Important**:
 
       - `CDK_EOAPI_DB_PGSTAC_VERSION` is a required env (see https://github.com/stac-utils/pgstac/tags for the latest version)

--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -160,7 +160,8 @@ class eoAPIconstruct(Stack):
             vpc=vpc,
             engine=rds.DatabaseInstanceEngine.POSTGRES,
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL
+                ec2.InstanceClass.BURSTABLE3,
+                ec2.InstanceSize(eodb_settings.instance_size),
             ),
             database_name="postgres",
             vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),

--- a/infrastructure/aws/cdk/config.py
+++ b/infrastructure/aws/cdk/config.py
@@ -39,6 +39,7 @@ class eoDBSettings(pydantic.BaseSettings):
 
     # Define PGSTAC VERSION
     pgstac_version: str
+    instance_size: str = "SMALL"
     context: bool = True
     mosaic_index: bool = True
 


### PR DESCRIPTION
Following up on discusion in #129.

While we wait for deployment of `eoapi-cdk` where database instance size is configurable, this makes it possible to specify the instance size via the `CDK_EOAPI_DB_INSTANCE_SIZE` environment variable.