### PR TITLE
update collections endpoit in raster API

### DIFF
--- a/.github/workflows/tests/test_raster.py
+++ b/.github/workflows/tests/test_raster.py
@@ -188,3 +188,16 @@ def test_item():
         in resp.json()["tiles"][0]
     )
     assert resp.json()["bounds"] == [-85.5501, 36.1749, -85.5249, 36.2001]
+
+
+def test_collections():
+    """test collection endpoints."""
+    resp = httpx.get(
+        f"{raster_endpoint}/collections",
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/json"
+
+    collections = resp.json()
+    assert len(collections) == 1
+    assert collections[0]["id"] == "noaa-emergency-response"

--- a/runtime/eoapi/raster/eoapi/raster/app.py
+++ b/runtime/eoapi/raster/eoapi/raster/app.py
@@ -9,6 +9,7 @@ from eoapi.raster import __version__ as eoapi_raster_version
 from eoapi.raster.config import ApiSettings
 from fastapi import Depends, FastAPI, Query
 from psycopg import OperationalError
+from psycopg.rows import dict_row
 from psycopg_pool import PoolTimeout
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -118,9 +119,10 @@ async def mosaic_builder(request: Request):
 async def list_collection(request: Request):
     """list collections."""
     with request.app.state.dbpool.connection() as conn:
-        with conn.cursor() as cursor:
-            cursor.execute("SELECT * FROM collections;")
-            return [t[2] for t in cursor.fetchall() if t]
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute("SELECT * FROM pgstac.all_collections();")
+            r = cursor.fetchone()
+            return r.get("all_collections", [])
 
 
 app.include_router(mosaic.router, tags=["Mosaic"], prefix="/mosaic")


### PR DESCRIPTION
`cursor.execute("SELECT * FROM collections;")` was failing with the test collection because of the `null` value for the datetime interval. It's better to use the PgSTAC function anyway 