### PR TITLE
update raster and vector services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     # At the time of writing, rasterio and psycopg wheels are not available for arm64 arch
     # so we force the image to be built with linux/amd64
     platform: linux/amd64
-    image: ghcr.io/stac-utils/titiler-pgstac:0.8.0
+    image: ghcr.io/stac-utils/titiler-pgstac:1.0.0a3
     ports:
       - "${MY_DOCKER_IP:-127.0.0.1}:8082:8082"
     environment:
@@ -89,7 +89,7 @@ services:
       - ./dockerfiles/scripts:/tmp/scripts
 
   tipg:
-    image: ghcr.io/developmentseed/tipg:0.4.4
+    image: ghcr.io/developmentseed/tipg:0.5.0
     ports:
       - "${MY_DOCKER_IP:-127.0.0.1}:8083:8083"
     environment:

--- a/runtime/eoapi/raster/eoapi/raster/app.py
+++ b/runtime/eoapi/raster/eoapi/raster/app.py
@@ -21,8 +21,13 @@ from titiler.core.factory import AlgorithmFactory, MultiBaseTilerFactory, TMSFac
 from titiler.core.middleware import CacheControlMiddleware
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 from titiler.pgstac.db import close_db_connection, connect_to_db
-from titiler.pgstac.dependencies import ItemPathParams
-from titiler.pgstac.factory import MosaicTilerFactory
+from titiler.pgstac.dependencies import CollectionIdParams, ItemIdParams, SearchIdParams
+from titiler.pgstac.extensions import searchInfoExtension
+from titiler.pgstac.factory import (
+    MosaicTilerFactory,
+    add_search_list_route,
+    add_search_register_route,
+)
 from titiler.pgstac.reader import PgSTACReader
 
 try:
@@ -86,34 +91,6 @@ app.add_middleware(
 )
 
 ###############################################################################
-# MOSAIC Endpoints
-mosaic = MosaicTilerFactory(
-    router_prefix="/mosaic",
-    # add /statistics [POST]
-    add_statistics=True,
-    # add /map viewer
-    add_viewer=True,
-    # add /mosaic/list endpoint
-    add_mosaic_list=True,
-    # add `/bbox` and `/feature [POST]` endpoint
-    add_part=False,
-)
-
-
-@mosaic.router.get("/builder", response_class=HTMLResponse)
-async def mosaic_builder(request: Request):
-    """Mosaic Builder Viewer."""
-    return templates.TemplateResponse(
-        name="mosaic-builder.html",
-        context={
-            "request": request,
-            "register_endpoint": mosaic.url_for(request, "register_search"),
-            "collections_endpoint": str(request.url_for("list_collection")),
-        },
-        media_type="text/html",
-    )
-
-
 # `Secret` endpoint for mosaic builder. Do not need to be public (in the OpenAPI docs)
 @app.get("/collections", include_in_schema=False)
 async def list_collection(request: Request):
@@ -125,16 +102,88 @@ async def list_collection(request: Request):
             return r.get("all_collections", [])
 
 
-app.include_router(mosaic.router, tags=["Mosaic"], prefix="/mosaic")
+###############################################################################
+# STAC Search Endpoints
+searches = MosaicTilerFactory(
+    path_dependency=SearchIdParams,
+    router_prefix="/searches/{search_id}",
+    add_statistics=True,
+    add_viewer=True,
+    add_part=True,
+    extensions=[
+        searchInfoExtension(),
+    ],
+)
+app.include_router(
+    searches.router, tags=["STAC Search"], prefix="/searches/{search_id}"
+)
+
+add_search_register_route(
+    app,
+    prefix="/searches",
+    tile_dependencies=[
+        searches.layer_dependency,
+        searches.dataset_dependency,
+        searches.pixel_selection_dependency,
+        searches.tile_dependency,
+        searches.process_dependency,
+        searches.rescale_dependency,
+        searches.colormap_dependency,
+        searches.render_dependency,
+        searches.pgstac_dependency,
+        searches.reader_dependency,
+        searches.backend_dependency,
+    ],
+    tags=["STAC Search"],
+)
+add_search_list_route(app, prefix="/searches", tags=["STAC Search"])
+
+
+@app.get("/searches/builder", response_class=HTMLResponse, tags=["STAC Search"])
+async def virtual_mosaic_builder(request: Request):
+    """Mosaic Builder Viewer."""
+    base_url = str(request.base_url)
+    return templates.TemplateResponse(
+        name="mosaic-builder.html",
+        context={
+            "request": request,
+            "register_endpoint": str(
+                app.url_path_for("register_search").make_absolute_url(base_url=base_url)
+            ),
+            "collections_endpoint": str(
+                app.url_path_for("list_collection").make_absolute_url(base_url=base_url)
+            ),
+        },
+        media_type="text/html",
+    )
+
+
+###############################################################################
+# STAC COLLECTION Endpoints
+collection = MosaicTilerFactory(
+    path_dependency=CollectionIdParams,
+    router_prefix="/collections/{collection_id}",
+    add_statistics=True,
+    add_viewer=True,
+    add_part=True,
+)
+app.include_router(
+    collection.router, tags=["STAC Collection"], prefix="/collections/{collection_id}"
+)
+
 
 ###############################################################################
 # STAC Item Endpoints
 stac = MultiBaseTilerFactory(
     reader=PgSTACReader,
-    path_dependency=ItemPathParams,
+    path_dependency=ItemIdParams,
     router_prefix="/collections/{collection_id}/items/{item_id}",
-    # add /map viewer
     add_viewer=True,
+)
+app.include_router(
+    stac.router,
+    tags=["STAC Item"],
+    prefix="/collections/{collection_id}/items/{item_id}",
 )
 
 
@@ -155,8 +204,11 @@ def viewer(request: Request, item: pystac.Item = Depends(stac.path_dependency)):
 
 
 app.include_router(
-    stac.router, tags=["Item"], prefix="/collections/{collection_id}/items/{item_id}"
+    stac.router,
+    tags=["STAC Item"],
+    prefix="/collections/{collection_id}/items/{item_id}",
 )
+
 
 ###############################################################################
 # Tiling Schemes Endpoints
@@ -216,44 +268,52 @@ def landing(request: Request):
                 "rel": "service-doc",
             },
             {
-                "title": "STAC Item Asset's Info (template URL)",
-                "href": stac.url_for(request, "info"),
+                "title": "PgSTAC Virtual Mosaic list (JSON)",
+                "href": str(app.url_path_for("list_searches")),
                 "type": "application/json",
                 "rel": "data",
             },
             {
-                "title": "STAC Item Viewer (template URL)",
-                "href": stac.url_for(request, "viewer"),
+                "title": "PgSTAC Virtual Mosaic builder",
+                "href": str(app.url_path_for("virtual_mosaic_builder")),
                 "type": "text/html",
                 "rel": "data",
             },
             {
-                "title": "STAC Mosaic List (JSON)",
-                "href": mosaic.url_for(request, "list_mosaic"),
-                "type": "application/json",
-                "rel": "data",
-            },
-            {
-                "title": "STAC Mosaic Builder",
-                "href": mosaic.url_for(request, "mosaic_builder"),
+                "title": "PgSTAC Virtual Mosaic viewer (template URL)",
+                "href": str(app.url_path_for("map_viewer", search_id="{search_id}")),
                 "type": "text/html",
                 "rel": "data",
             },
             {
-                "title": "STAC Mosaic Metadata (template URL)",
-                "href": mosaic.url_for(request, "info_search", searchid="{searchid}"),
-                "type": "application/json",
-                "rel": "data",
-            },
-            {
-                "title": "STAC Mosaic viewer (template URL)",
-                "href": mosaic.url_for(request, "map_viewer", searchid="{searchid}"),
+                "title": "PgSTAC Collection viewer (template URL)",
+                "href": str(
+                    app.url_path_for("map_viewer", collection_id="{collection_id}")
+                ),
                 "type": "text/html",
                 "rel": "data",
             },
             {
-                "title": "TiTiler-pgSTAC Documentation (external link)",
+                "title": "PgSTAC Item viewer (template URL)",
+                "href": str(
+                    app.url_path_for(
+                        "map_viewer",
+                        collection_id="{collection_id}",
+                        item_id="{item_id}",
+                    )
+                ),
+                "type": "text/html",
+                "rel": "data",
+            },
+            {
+                "title": "TiTiler-PgSTAC Documentation (external link)",
                 "href": "https://stac-utils.github.io/titiler-pgstac/",
+                "type": "text/html",
+                "rel": "doc",
+            },
+            {
+                "title": "TiTiler-PgSTAC source code (external link)",
+                "href": "https://github.com/stac-utils/titiler-pgstac",
                 "type": "text/html",
                 "rel": "doc",
             },

--- a/runtime/eoapi/raster/eoapi/raster/templates/mosaic-builder.html
+++ b/runtime/eoapi/raster/eoapi/raster/templates/mosaic-builder.html
@@ -596,7 +596,7 @@ document.getElementById('btn-query').addEventListener('click', () => {
       var info_link = data.links.filter((link) => link.rel  == 'metadata');
       var tilejson_link = data.links.filter((link) => link.rel  == 'tilejson');
       var map_link = data.links.filter((link) => link.rel  == 'map');
-      var mosaic_info_str = `<p class="mt6">MosaicID: <strong>${data.searchid}</strong></p><p>Links:</p>`
+      var mosaic_info_str = `<p class="mt6">MosaicID: <strong>${data.id}</strong></p><p>Links:</p>`
       if (info_link) {
         mosaic_info_str += `<p class="mt6">- <a href="${info_link[0].href}" target="_blank">Mosaic Info Link</a></p>`
       }

--- a/runtime/eoapi/raster/pyproject.toml
+++ b/runtime/eoapi/raster/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler.pgstac==0.8.0",
+    "titiler.pgstac==1.0.0a3",
     "starlette-cramjam>=0.3,<0.4",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]

--- a/runtime/eoapi/vector/pyproject.toml
+++ b/runtime/eoapi/vector/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "tipg==0.4.4",
+    "tipg==0.5.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
closes #146 

This PR update the custom runtimes:

### Vector 
- update tipg to version `0.5.0` 

### Raster
- update titiler-pgstac to `1.0.0a3`
- add `/collections/{collection_id}` endpoinds
- rename `/mosaic/{search_id}` to `/searches/{search_id}`