### PR TITLE
add /cog/ endpoints in raster service

### DIFF
--- a/.github/workflows/tests/test_raster.py
+++ b/.github/workflows/tests/test_raster.py
@@ -235,3 +235,15 @@ def test_collections():
     collections = resp.json()
     assert len(collections) == 1
     assert collections[0]["id"] == "noaa-emergency-response"
+
+
+def test_cog_endpoints():
+    """test /cog endpoints"""
+    resp = httpx.get(
+        f"{raster_endpoint}/cog/info",
+        params={
+            "url": "https://noaa-eri-pds.s3.us-east-1.amazonaws.com/2020_Nashville_Tornado/20200307a_RGB/20200307aC0854500w361030n.tif",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/json"

--- a/runtime/eoapi/raster/eoapi/raster/app.py
+++ b/runtime/eoapi/raster/eoapi/raster/app.py
@@ -17,8 +17,14 @@ from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
 from starlette_cramjam.middleware import CompressionMiddleware
 from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from titiler.core.factory import AlgorithmFactory, MultiBaseTilerFactory, TMSFactory
+from titiler.core.factory import (
+    AlgorithmFactory,
+    MultiBaseTilerFactory,
+    TilerFactory,
+    TMSFactory,
+)
 from titiler.core.middleware import CacheControlMiddleware
+from titiler.extensions import cogViewerExtension
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 from titiler.pgstac.db import close_db_connection, connect_to_db
 from titiler.pgstac.dependencies import CollectionIdParams, ItemIdParams, SearchIdParams
@@ -209,6 +215,17 @@ app.include_router(
     prefix="/collections/{collection_id}/items/{item_id}",
 )
 
+
+###############################################################################
+# COG Endpoints
+cog = TilerFactory(
+    router_prefix="/cog",
+    extensions=[
+        cogViewerExtension(),
+    ],
+)
+
+app.include_router(cog.router, prefix="/cog", tags=["Cloud Optimized GeoTIFF"])
 
 ###############################################################################
 # Tiling Schemes Endpoints

--- a/runtime/eoapi/raster/pyproject.toml
+++ b/runtime/eoapi/raster/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "titiler.pgstac==1.0.0a3",
+    "titiler.extensions",
     "starlette-cramjam>=0.3,<0.4",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]


### PR DESCRIPTION
This PR add `/cog` endpoints to access external Cloud Optimized dataset (using `url=...` parameter)

<img width="743" src="https://github.com/developmentseed/eoAPI/assets/10407788/9cd4389c-7397-49d7-a64d-f09f7d3e7dd1">
