### PR TITLE
Fix port in local browser deployment 

### DIFF
--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -21,12 +21,12 @@ FROM nginx:1-alpine-slim
 COPY --from=build-step /app/dist /usr/share/nginx/html
 COPY --from=build-step /app/config.schema.json /etc/nginx/conf.d/config.schema.json
 
-# change default port to 8084
+# change default port to 8085
 RUN apk add jq pcre-tools && \
-    sed -i 's/\s*listen\s*80;/    listen 8084;/' /etc/nginx/conf.d/default.conf && \
+    sed -i 's/\s*listen\s*80;/    listen 8085;/' /etc/nginx/conf.d/default.conf && \
     sed -i 's/\s*location \/ {/    location \/ {\n        try_files $uri $uri\/ \/index.html;/' /etc/nginx/conf.d/default.conf
 
-EXPOSE 8084
+EXPOSE 8085
 
 STOPSIGNAL SIGTERM
 


### PR DESCRIPTION
The port in the docker compose config didn't match the port exposed in the docker image. Fixed to expose port 8085 consistently.

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
