### PR TITLE
update titiler and tipg requirements

### DIFF
--- a/runtime/eoapi/raster/eoapi/raster/app.py
+++ b/runtime/eoapi/raster/eoapi/raster/app.py
@@ -4,6 +4,7 @@ import logging
 from contextlib import asynccontextmanager
 from typing import Dict
 
+import jinja2
 import pystac
 from eoapi.raster import __version__ as eoapi_raster_version
 from eoapi.raster.config import ApiSettings
@@ -36,20 +37,20 @@ from titiler.pgstac.factory import (
 )
 from titiler.pgstac.reader import PgSTACReader
 
-try:
-    from importlib.resources import files as resources_files  # type: ignore
-except ImportError:
-    # Try backported to PY<39 `importlib_resources`.
-    from importlib_resources import files as resources_files  # type: ignore
-
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
 logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 
 settings = ApiSettings()
 
-# TODO: mypy fails in python 3.9, we need to find a proper way to do this
-templates = Jinja2Templates(directory=str(resources_files(__package__) / "templates"))  # type: ignore
+jinja2_env = jinja2.Environment(
+    loader=jinja2.ChoiceLoader(
+        [
+            jinja2.PackageLoader(__package__, "templates"),
+        ]
+    )
+)
+templates = Jinja2Templates(env=jinja2_env)
 
 
 @asynccontextmanager

--- a/runtime/eoapi/raster/pyproject.toml
+++ b/runtime/eoapi/raster/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler.pgstac==1.0.0a3",
+    "titiler.pgstac==1.1.0",
     "titiler.extensions",
     "starlette-cramjam>=0.3,<0.4",
     "importlib_resources>=1.1.0;python_version<'3.9'",

--- a/runtime/eoapi/vector/eoapi/vector/app.py
+++ b/runtime/eoapi/vector/eoapi/vector/app.py
@@ -64,15 +64,15 @@ app = FastAPI(
 )
 
 # add eoapi_vector templates and tipg templates
-templates = Jinja2Templates(  # type: ignore
-    directory="",
+jinja2_env = jinja2.Environment(
     loader=jinja2.ChoiceLoader(
         [
             jinja2.PackageLoader(__package__, "templates"),
             jinja2.PackageLoader("tipg", "templates"),
         ]
-    ),
+    )
 )
+templates = Jinja2Templates(env=jinja2_env)
 
 # Register TiPg endpoints.
 endpoints = TiPgEndpoints(

--- a/runtime/eoapi/vector/pyproject.toml
+++ b/runtime/eoapi/vector/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "tipg==0.5.0",
+    "tipg==0.6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR Does:

#### eoapi.raster
- update to titiler-pgstac 1.1.0
- adapt to avoid starlette breaking change

#### eoapi.vector
- update to tipg 0.6.0 
- adapt to avoid starlette breaking change
