### PR TITLE
fix items and collection download and pypgstac installation

### DIFF
--- a/demo/Maxar/eoAPI_Maxar_demo.ipynb
+++ b/demo/Maxar/eoAPI_Maxar_demo.ipynb
@@ -68,7 +68,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -m pip install pypgstac==0.8.1"
+    "!python -m pip install \"pypgstac[psycopg]==0.8.1\""
    ]
   },
   {
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "# Download the collections file\n",
-    "!curl https://raw.githubusercontent.com/vincentsarago/MAXAR_opendata_to_pgstac/main/collections_assets.json > collections.json"
+    "!wget https://github.com/vincentsarago/MAXAR_opendata_to_pgstac/raw/main/Maxar/collections.json"
    ]
   },
   {
@@ -90,7 +90,7 @@
    "outputs": [],
    "source": [
     "# Download the items file\n",
-    "!curl https://raw.githubusercontent.com/vincentsarago/MAXAR_opendata_to_pgstac/main/items_s3.json > items.json"
+    "! wget https://github.com/vincentsarago/MAXAR_opendata_to_pgstac/raw/main/Maxar/items.json.zip && unzip items.json.zip && rm -rf items.json.zip"
    ]
   },
   {
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "af16cb95",
    "metadata": {},
    "outputs": [],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "f7ded3bc",
    "metadata": {
     "scrolled": true
@@ -134,24 +134,12 @@
     "\n",
     "See https://github.com/stac-utils/pgstac/blob/main/docs/src/pgstac.md#pgstac-settings-variables\n",
     "\n",
-    "The PgSTAC Context extension is not enabled by default because it's \"slows\" down the `/search` request but for this Demo we want it enabled.\n",
-    "\n",
-    "**Requirements**: `psycopg[binary]`"
+    "The PgSTAC Context extension is not enabled by default because it's \"slows\" down the `/search` request but for this Demo we want it enabled."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "11c68484",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!python -m pip install psycopg[binary]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "dc3fa136",
    "metadata": {},
    "outputs": [],
@@ -1039,7 +1027,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I was exploring a potential issue raised in a discussion and this made me realize the current maxar demo notebook was broken : 

- the collection and item download cells were broken. Changed to download from https://github.com/vincentsarago/MAXAR_opendata_to_pgstac using `wget`.
- the cells inserting the metadata to the DB were broken because we were missing the `psycopg` dependency. I added it at the top. 
