### PR TITLE
Enable ability to customize concurrency of gunicorn processes

### DIFF
--- a/docker-compose.custom.yml
+++ b/docker-compose.custom.yml
@@ -29,11 +29,7 @@ services:
       - PORT=8081
       - ENVIRONMENT=local
       # https://github.com/tiangolo/uvicorn-gunicorn-docker#web_concurrency
-      - WEB_CONCURRENCY=10
-      # https://github.com/tiangolo/uvicorn-gunicorn-docker#workers_per_core
-      # - WORKERS_PER_CORE=1
-      # https://github.com/tiangolo/uvicorn-gunicorn-docker#max_workers
-      # - MAX_WORKERS=10
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY:-10}
       # Postgres connection
       - POSTGRES_USER=username
       - POSTGRES_PASS=password
@@ -74,11 +70,7 @@ services:
       - HOST=0.0.0.0
       - PORT=8082
       # https://github.com/tiangolo/uvicorn-gunicorn-docker#web_concurrency
-      - WEB_CONCURRENCY=1
-      # https://github.com/tiangolo/uvicorn-gunicorn-docker#workers_per_core
-      - WORKERS_PER_CORE=1
-      # https://github.com/tiangolo/uvicorn-gunicorn-docker#max_workers
-      - MAX_WORKERS=10
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY:-10}
       # Postgres connection
       - POSTGRES_USER=username
       - POSTGRES_PASS=password
@@ -127,11 +119,7 @@ services:
       - HOST=0.0.0.0
       - PORT=8083
       # https://github.com/tiangolo/uvicorn-gunicorn-docker#web_concurrency
-      - WEB_CONCURRENCY=10
-      # https://github.com/tiangolo/uvicorn-gunicorn-docker#workers_per_core
-      # - WORKERS_PER_CORE=1
-      # https://github.com/tiangolo/uvicorn-gunicorn-docker#max_workers
-      # - MAX_WORKERS=10
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY:-10}
       # Postgres connection
       - POSTGRES_USER=username
       - POSTGRES_PASS=password


### PR DESCRIPTION
To minimize chatter in the Docker logs, it's nice to be able to disable web concurrency for gunicorn processes.

NOTE: It may be nice to have concurrency be set to `1` by default. I'm assuming the average person running this docker file will be a developer working on their eoAPI solutions locally, when high concurrency is not a strong need.