### PR TITLE
Update Maxar demo to work with referenced version of pgstac-titiler

### DIFF
--- a/demo/Maxar/eoAPI_Maxar_demo.ipynb
+++ b/demo/Maxar/eoAPI_Maxar_demo.ipynb
@@ -379,9 +379,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7f77306d",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "m = ipyleaflet.leaflet.Map(\n",
@@ -422,9 +420,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "56ba6e0c",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "item = kahramanmaras_items[0]\n",
@@ -704,7 +700,7 @@
    "outputs": [],
    "source": [
     "pre_mosaic = httpx.post(\n",
-    "    f\"{raster_endpoint}/mosaic/register\",\n",
+    "    f\"{raster_endpoint}/searches/register\",\n",
     "    data=json.dumps(\n",
     "        {\n",
     "            \"filter-lang\": 'cql2-json',\n",
@@ -739,7 +735,7 @@
     ").json()\n",
     "\n",
     "post_mosaic = httpx.post(\n",
-    "    f\"{raster_endpoint}/mosaic/register\",\n",
+    "    f\"{raster_endpoint}/searches/register\",\n",
     "    data=json.dumps(\n",
     "        {\n",
     "            \"filter-lang\": 'cql2-json',\n",
@@ -851,10 +847,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mosaic_id = pre_mosaic[\"searchid\"]\n",
+    "search_id = pre_mosaic[\"id\"]\n",
     "\n",
     "tilejson_pre = httpx.get(\n",
-    "    f\"{raster_endpoint}/mosaic/{mosaic_id}/tilejson.json\",\n",
+    "    f\"{raster_endpoint}/searches/{search_id}/tilejson.json\",\n",
     "    params = (\n",
     "        (\"assets\", \"visual\"),  # THIS IS MANDATORY\n",
     "        (\"minzoom\", 12),\n",
@@ -900,10 +896,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mosaic_id = post_mosaic[\"searchid\"]\n",
+    "search_id = post_mosaic[\"id\"]\n",
     "\n",
     "tilejson_post = httpx.get(\n",
-    "    f\"{raster_endpoint}/mosaic/{mosaic_id}/tilejson.json\",\n",
+    "    f\"{raster_endpoint}/searches/{search_id}/tilejson.json\",\n",
     "    params = (\n",
     "        (\"assets\", \"visual\"),  # THIS IS MANDATORY\n",
     "        (\"minzoom\", 12),\n",
@@ -1027,7 +1023,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The Maxar demo refers to registering mosaics, but the most recent version of pgstac-titiler (or at least the version used in the docker compose) relies on registering searches instead. Seems registering mosaics is outdated. I updated the maxar demo to now work with the titiler-pgstac endpoints. 

![image](https://github.com/developmentseed/eoAPI/assets/37987755/aa052270-5c7a-43d7-9bde-357e33cf2a34)
