### PR TITLE
fix link to stac-fastapi.pgstac

### DIFF
--- a/docs/src/customization.md
+++ b/docs/src/customization.md
@@ -3,7 +3,7 @@ The eoAPI repository (https://github.com/developmentseed/eoAPI) hosts customized
 ---
 ## eoapi.stac
 
-Built on [stac-fastapi.pgstac](https://github.com/stac-utils/stac-fastapi) application, adding a **`TiTilerExtension`** and a simple **`Search Viewer`**.
+Built on [stac-fastapi.pgstac](https://github.com/stac-utils/stac-fastapi-pgstac) application, adding a **`TiTilerExtension`** and a simple **`Search Viewer`**.
 
 The service includes:
 


### PR DESCRIPTION
The link out to stac-fastapi.pgstac was sending users to stac-fastapi repo.
