### PR TITLE
Maxar Demo: Fix pypgstac version

### DIFF
--- a/demo/Maxar/eoAPI_Maxar_demo.ipynb
+++ b/demo/Maxar/eoAPI_Maxar_demo.ipynb
@@ -56,7 +56,7 @@
     "**Items**: https://raw.githubusercontent.com/vincentsarago/MAXAR_opendata_to_pgstac/main/items_s3.json\n",
     "\n",
     "\n",
-    "**Requirements**: `pypgstac==0.8.1`\n"
+    "**Requirements**: `pypgstac==0.9.2`\n"
    ]
   },
   {
@@ -68,7 +68,7 @@
    },
    "outputs": [],
    "source": [
-    "!python -m pip install \"pypgstac[psycopg]==0.8.1\""
+    "!python -m pip install \"pypgstac[psycopg]==0.9.2\""
    ]
   },
   {


### PR DESCRIPTION
## What I am changing

- Update the version of pypgstac installed as part of the Maxar demo notebook

## Why I did it

I am using eoAPI for the first time. Following the setup instructions, I ran `docker-compose up` to setup my environment. I then attempted to run the Maxar demo notebook. 

I got an error when running the following command:

```sh
# Ingest the collections
!pypgstac load collections collections.json --dsn postgresql://username:password@0.0.0.0:5439/postgis --method insert_ignore
```

> Exception: pypgstac version 0.8.1 is not compatible with the target database version 0.9.2. database version 0.9.2.

I noticed that the `database` service in docker-compose.yml is using `ghcr.io/stac-utils/pgstac:v0.9.2`. Updating the jupyter cell to install v0.9.2 fixed the issue.

```sh
!python -m pip install "pypgstac[psycopg]==0.9.2"
```

## How you can test it

- Clone this repo
- Run `docker-compose up`
- Open the Maxar demo notebook in jupyter
- Run the updated `pip install "pypgstac[psycopg]==0.9.2"` command
- Run the following cells, up to and including the `pypgstac load collections` cell
- You should not see errors, and the data should be loaded into your pgstac db.

----

Thank you so much for your work on this project! I'm excited to try it out 😀 🌍