### PR TITLE
Set PgSTAC database platform for arm64 hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,9 @@ services:
       - ./dockerfiles/scripts:/tmp/scripts
 
   database:
+    # The PgSTAC image does not publish an arm64 manifest for this tag, so run
+    # the amd64 image under emulation on Apple Silicon and other arm64 hosts.
+    platform: linux/amd64
     image: ghcr.io/stac-utils/pgstac:v0.9.6
     environment:
       - POSTGRES_USER=username


### PR DESCRIPTION
Closes #153

Adds an explicit `linux/amd64` platform for the PgSTAC database image in `docker-compose.yml`.

The compose file already uses this approach for `titiler-pgstac` because some dependency images do not publish arm64-compatible manifests. This applies the same handling to the PgSTAC database service so Apple Silicon and other arm64 Docker hosts can run the stack through emulation instead of failing with `no matching manifest for linux/arm64/v8`.

Validation:
- Ran `git diff --check`
- Ran `docker compose config`
- Ran `docker compose pull database`
- Ran `docker compose up -d database` and verified the database container started successfully